### PR TITLE
Make edx-api-doc-tools installable in Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,28 @@ env:
 
 matrix:
   include:
+    # Most IDAs are Python 3.5 and Django 1.11. Test and run codecov on those.
     - python: 3.5
-      env: TOXENV=django111
-    - python: 3.6
-      env: TOXENV=django111
+      env: TOXENV=django111-drf39 AFTER_SUCCESS=codecov
+    # Test Python 3.5 with all Django versions and latest DRF.
     - python: 3.5
-      env: TOXENV=django20
+      env: TOXENV=django111-drflatest
+    - python: 3.5
+      env: TOXENV=django20-drflatest
+    - python: 3.5
+      env: TOXENV=django21-drflatest
+    - python: 3.5
+      env: TOXENV=django22-drflatest
+    # Test Python 3.6 with all Django versions and latest DRF.
     - python: 3.6
-      env: TOXENV=django20
+      env: TOXENV=django111-drflatest
     - python: 3.6
-      env: TOXENV=docs
+      env: TOXENV=django20-drflatest
+    - python: 3.6
+      env: TOXENV=django21-drflatest
+    - python: 3.6
+      env: TOXENV=django22-drflatest
+    # Test quality in just Python 3.5.
     - python: 3.5
       env:
         - COMMAND="make quality"
@@ -37,7 +49,7 @@ script:
   - $COMMAND
 
 after_success:
-  - codecov
+  - true; ${AFTER_SUCCESS} # "true; " on its own is no-op
 
 deploy:
   provider: pypi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,17 @@ Change Log
 Unreleased
 ----------
 
-* Added documentation
+
+1.1.0 --- 2020-03-20
+--------------------
+
+* Compatibility with Django 2.1 and 2.2.
+
+
+1.0.3 --- 2020-01-31
+--------------------
+
+* Added documentation.
 
 
 1.0.2 --- 2020-01-17

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,11 @@ upgrade: upgrade-pip-tools ## update the requirements/*.txt files with the lates
 	pip-compile --upgrade requirements/quality.in
 	pip-compile --upgrade requirements/travis.in
 	pip-compile --upgrade requirements/dev.in
-	# Let tox control the Django version for tests
-	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
-	mv requirements/test.tmp requirements/test.txt
+	# Delete django, drf pins from test.txt so that tox can control
+	# Django version.
+	sed -i.tmp '/^[dD]jango==/d' requirements/test.txt
+	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt
+	rm requirements/test.txt.tmp
 
 CHECKABLE_PYTHON=tests test_utils example edx_api_doc_tools manage.py setup.py test_settings.py
 

--- a/edx_api_doc_tools/__init__.py
+++ b/edx_api_doc_tools/__init__.py
@@ -40,6 +40,6 @@ from .data import (
 from .view_utils import is_schema_request, schema, schema_for
 
 
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 
 default_app_config = 'edx_api_doc_tools.apps.EdxApiDocToolsConfig'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Core requirements for using this application
 -c constraints.txt
 
-djangorestframework
+Django>=1.11,<3.0
+djangorestframework>=3.2.0
 drf-yasg
-Django>=1.11,<2.1          # Web application framework

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
-django==2.0.13            # via -r requirements/base.in, djangorestframework, drf-yasg
+django==2.2.11            # via -r requirements/base.in, djangorestframework, drf-yasg
 djangorestframework==3.11.0  # via -r requirements/base.in, drf-yasg
 drf-yasg==1.17.1          # via -r requirements/base.in
 idna==2.9                 # via requests
@@ -23,5 +23,6 @@ requests==2.23.0          # via coreapi
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via drf-yasg
 six==1.14.0               # via drf-yasg, packaging
+sqlparse==0.3.1           # via django
 uritemplate==3.0.1        # via coreapi, drf-yasg
 urllib3==1.25.8           # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ coreschema==0.0.4         # via -r requirements/quality.txt, coreapi, drf-yasg
 coverage==5.0.4           # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
 diff-cover==2.6.0         # via -r requirements/dev.in
 distlib==0.3.0            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
-django==2.0.13            # via -r requirements/quality.txt, djangorestframework, drf-yasg, edx-i18n-tools
+django==2.2.11            # via -r requirements/quality.txt, djangorestframework, drf-yasg, edx-i18n-tools
 djangorestframework==3.11.0  # via -r requirements/quality.txt, drf-yasg
 docutils==0.16            # via -r requirements/quality.txt, readme-renderer
 drf-yasg==1.17.1          # via -r requirements/quality.txt
@@ -70,6 +70,7 @@ ruamel.yaml.clib==0.2.0   # via -r requirements/quality.txt, ruamel.yaml
 ruamel.yaml==0.16.10      # via -r requirements/quality.txt, drf-yasg
 six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, bleach, diff-cover, drf-yasg, edx-i18n-tools, edx-lint, packaging, pathlib2, pip-tools, readme-renderer, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
+sqlparse==0.3.1           # via -r requirements/quality.txt, django
 toml==0.10.0              # via -r requirements/travis.txt, tox
 tox-battery==0.5.2        # via -r requirements/dev.in
 tox==3.14.5               # via -r requirements/travis.txt, tox-battery

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -13,7 +13,7 @@ chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 coreapi==2.3.3            # via -r requirements/test.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi, drf-yasg
 coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
-django==2.0.13            # via -r requirements/test.txt, djangorestframework, drf-yasg
+django==2.2.11            # via -r requirements/test.txt, djangorestframework, drf-yasg
 djangorestframework==3.11.0  # via -r requirements/test.txt, drf-yasg
 doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
@@ -54,6 +54,7 @@ sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via doc8
 tqdm==4.43.0              # via twine
 twine==1.15.0             # via -r requirements/doc.in

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.1.1              # via pip-tools
-pip-tools==4.5.1
+pip-tools==4.5.1          # via -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -18,7 +18,7 @@ coreapi==2.3.3            # via -r requirements/test.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi, drf-yasg
 coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
 distlib==0.3.0            # via caniusepython3
-django==2.0.13            # via -r requirements/test.txt, djangorestframework, drf-yasg
+django==2.2.11            # via -r requirements/test.txt, djangorestframework, drf-yasg
 djangorestframework==3.11.0  # via -r requirements/test.txt, drf-yasg
 docutils==0.16            # via readme-renderer
 drf-yasg==1.17.1          # via -r requirements/test.txt
@@ -57,6 +57,7 @@ ruamel.yaml.clib==0.2.0   # via -r requirements/test.txt, ruamel.yaml
 ruamel.yaml==0.16.10      # via -r requirements/test.txt, drf-yasg
 six==1.14.0               # via -r requirements/test.txt, astroid, bleach, drf-yasg, edx-lint, packaging, pathlib2, readme-renderer
 snowballstemmer==2.0.0    # via pydocstyle
+sqlparse==0.3.1           # via -r requirements/test.txt, django
 tqdm==4.43.0              # via twine
 twine==1.15.0             # via -r requirements/quality.in
 typed-ast==1.4.1          # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,6 @@ chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
 coverage==5.0.4           # via pytest-cov
-djangorestframework==3.11.0  # via -r requirements/base.txt, drf-yasg
 drf-yasg==1.17.1          # via -r requirements/base.txt
 idna==2.9                 # via -r requirements/base.txt, requests
 importlib-metadata==1.5.0  # via pluggy, pytest
@@ -32,6 +31,7 @@ requests==2.23.0          # via -r requirements/base.txt, coreapi
 ruamel.yaml.clib==0.2.0   # via -r requirements/base.txt, ruamel.yaml
 ruamel.yaml==0.16.10      # via -r requirements/base.txt, drf-yasg
 six==1.14.0               # via -r requirements/base.txt, drf-yasg, packaging, pathlib2
+sqlparse==0.3.1           # via -r requirements/base.txt, django
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi, drf-yasg
 urllib3==1.25.8           # via -r requirements/base.txt, requests
 wcwidth==0.1.8            # via pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36}-django{111,20}
+envlist = {py35,py36}-django{111,20,21,22}-drf{39,latest}
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
@@ -10,6 +10,10 @@ norecursedirs = .* docs requirements
 deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
+    drf39: djangorestframework<3.10
+    drflatest: djangorestframework
     -r{toxinidir}/requirements/test.txt
 commands =
     pytest {posargs}


### PR DESCRIPTION
I need to do this in order to install `edx-api-doc-tools` into Registrar, which is on Django 2.2 now.

Changes (from commit message):
* Relax Django constraint to allow any version in [1.11, 3.0).
* Upgrade Python requirements for tests.
* Add Django 2.1 and 2.2 environments in Tox.
* Allow testing of different DRF versions just like we do with Django.
* On Travis, test more Django and DRF versions.
* On Travis, only run codecov on py35-django111-drf39.
* Bump version from 1.0.3 to 1.1.0.