### PR TITLE
[BD-6] Add python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,12 @@ env:
 
 matrix:
   include:
-    # Most IDAs are Python 3.5 and Django 1.11. Test and run codecov on those.
+    # Most IDAs are Python 3.5 and Django 2.2. Test and run codecov on those.
     - python: 3.5
-      env: TOXENV=django111-drf39 AFTER_SUCCESS=codecov
-    # Test Python 3.5 with all Django versions and latest DRF.
-    - python: 3.5
-      env: TOXENV=django111-drflatest
-    - python: 3.5
-      env: TOXENV=django20-drflatest
-    - python: 3.5
-      env: TOXENV=django21-drflatest
+      env: TOXENV=django22-drf39 AFTER_SUCCESS=codecov
     - python: 3.5
       env: TOXENV=django22-drflatest
-    # Test Python 3.6 with all Django versions and latest DRF.
-    - python: 3.6
-      env: TOXENV=django111-drflatest
-    - python: 3.6
-      env: TOXENV=django20-drflatest
-    - python: 3.6
-      env: TOXENV=django21-drflatest
-    - python: 3.6
+    - python: 3.8
       env: TOXENV=django22-drflatest
     # Test quality in just Python 3.5.
     - python: 3.5
@@ -57,6 +43,7 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    python: 3.5
     condition: '$DEPLOY_PYPI = true'
   password:
     secure: qOQ4kU13p2LicQ+5+EKhOYUuhLEtk+UaSp/gJmSuo5osxYXtEGIMi8jBaI2SS4oP0HpIfZ0ywhOHpR6bJx5+UCAX+Mwa9UJR28u20Tc0KkoB8TtBvDI9tnH6KQmsjeyCeBlVxo0VSFh/Ox1Ftu3fBsm3duai5xBBfx8yVM9R7hrEAvJwCysXpDEOY2LpcxLTZgtPm9cOwiuwPI0zqxPY+N4JrXxruwaSIuK8WhONl486k/CsWNEAtcHNcbG3XslkhlleRuKQoi/bp+lhZeOs8Ls43GbLxbk1PAk45zDtYB+kkYXPxsgau5fwsVChrw5XAXi6fw9xW0KveQbhXusuQXGbxw7qjXEuMLDC0XgSvLhAQUjTSRhgo+G3u/xl8cSo0dsMUiiBYwtp/3vwncrYrd8OUNgFZ0HpWehc5W5Mm9F8nBNpmAwaB0ESmSAazTYQmA1jQTcxKTgOKn4KMa9EoPlD37d/z10nq1BXugqcCZzheGKWzHa3MvdBfBeMmHaMrG8mUxEelghBxkd0Yh3I3+zk8qIvzem6DgGSbUpCJjkNUin3X6JOHFnpUtlRCaCiCismw5fhvsjyNJys4s/rkfhiADphsxUkRroR8T0szhWDmAssdm6rLin7cvuQ4iyA0hNoQL9AfW3SdL7DCuC2KuvIgPDg6cxd5TVtaem67i8=

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+1.3.0 --- 2020-04-30
+--------------------
+
+* Remove support for Django<2.2 and add support for python 3.8
+
 1.2.0 --- 2020-03-20
 --------------------
 

--- a/edx_api_doc_tools/__init__.py
+++ b/edx_api_doc_tools/__init__.py
@@ -47,6 +47,6 @@ from .view_utils import (
 )
 
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 default_app_config = 'edx_api_doc_tools.apps.EdxApiDocToolsConfig'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
@@ -12,17 +12,17 @@ django==2.2.12            # via -r requirements/base.in, djangorestframework, dr
 djangorestframework==3.11.0  # via -r requirements/base.in, drf-yasg
 drf-yasg==1.17.1          # via -r requirements/base.in
 idna==2.9                 # via requests
-inflection==0.3.1         # via drf-yasg
-itypes==1.1.0             # via coreapi
-jinja2==2.11.1            # via coreschema
+inflection==0.4.0         # via drf-yasg
+itypes==1.2.0             # via coreapi
+jinja2==2.11.2            # via coreschema
 markupsafe==1.1.1         # via jinja2
 packaging==20.3           # via drf-yasg
-pyparsing==2.4.6          # via packaging
-pytz==2019.3              # via django
+pyparsing==2.4.7          # via packaging
+pytz==2020.1              # via django
 requests==2.23.0          # via coreapi
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via drf-yasg
 six==1.14.0               # via drf-yasg, packaging
 sqlparse==0.3.1           # via django
 uritemplate==3.0.1        # via coreapi, drf-yasg
-urllib3==1.25.8           # via requests
+urllib3==1.25.9           # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,17 +9,17 @@ argparse==1.4.0           # via -r requirements/quality.txt, caniusepython3
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/quality.txt, pytest
 backports.functools-lru-cache==1.6.1  # via -r requirements/quality.txt, caniusepython3
-bleach==3.1.4             # via -r requirements/quality.txt, readme-renderer
+bleach==3.1.5             # via -r requirements/quality.txt, readme-renderer
 caniusepython3==7.2.0     # via -r requirements/quality.txt
-certifi==2019.11.28       # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+certifi==2020.4.5.1       # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
-click==7.1.1              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
+click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
 codecov==2.0.22           # via -r requirements/travis.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/quality.txt, coreapi, drf-yasg
-coverage==5.0.4           # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
-diff-cover==2.6.0         # via -r requirements/dev.in
+coverage==5.1             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
+diff-cover==2.6.1         # via -r requirements/dev.in
 distlib==0.3.0            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
 django==2.2.12            # via -r requirements/quality.txt, djangorestframework, drf-yasg, edx-i18n-tools
 djangorestframework==3.11.0  # via -r requirements/quality.txt, drf-yasg
@@ -30,22 +30,22 @@ edx-lint==1.4.1           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 importlib-metadata==1.6.0  # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==1.4.0  # via -r requirements/travis.txt, virtualenv
+importlib-resources==1.5.0  # via -r requirements/travis.txt, virtualenv
 inflect==3.0.2            # via jinja2-pluralize
-inflection==0.3.1         # via -r requirements/quality.txt, drf-yasg
+inflection==0.4.0         # via -r requirements/quality.txt, drf-yasg
 isort==4.3.21             # via -r requirements/quality.txt, pylint
-itypes==1.1.0             # via -r requirements/quality.txt, coreapi
+itypes==1.2.0             # via -r requirements/quality.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.1            # via -r requirements/quality.txt, coreschema, diff-cover, jinja2-pluralize
+jinja2==2.11.2            # via -r requirements/quality.txt, coreschema, diff-cover, jinja2-pluralize
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 more-itertools==8.2.0     # via -r requirements/quality.txt, pytest
-packaging==20.3           # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, drf-yasg, pytest, tox
+packaging==20.3           # via -r requirements/quality.txt, -r requirements/travis.txt, bleach, caniusepython3, drf-yasg, pytest, tox
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
-pip-tools==4.5.1          # via -r requirements/pip-tools.txt
+pip-tools==5.1.0          # via -r requirements/pip-tools.txt
 pkginfo==1.5.0.1          # via -r requirements/quality.txt, twine
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
@@ -57,13 +57,13 @@ pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
 pylint==2.4.2             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.6          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
+pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/quality.txt
 pytest-django==3.9.0      # via -r requirements/quality.txt
 pytest==5.4.1             # via -r requirements/quality.txt, pytest-cov, pytest-django
-pytz==2019.3              # via -r requirements/quality.txt, django
+pytz==2020.1              # via -r requirements/quality.txt, django
 pyyaml==5.3.1             # via edx-i18n-tools
-readme-renderer==25.0     # via -r requirements/quality.txt, twine
+readme-renderer==26.0     # via -r requirements/quality.txt, twine
 requests-toolbelt==0.9.1  # via -r requirements/quality.txt, twine
 requests==2.23.0          # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, codecov, coreapi, requests-toolbelt, twine
 ruamel.yaml.clib==0.2.0   # via -r requirements/quality.txt, ruamel.yaml
@@ -78,12 +78,13 @@ tqdm==4.45.0              # via -r requirements/quality.txt, twine
 twine==1.15.0             # via -r requirements/quality.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, coreapi, drf-yasg
-urllib3==1.25.8           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-virtualenv==20.0.15       # via -r requirements/travis.txt, tox
+urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+virtualenv==20.0.18       # via -r requirements/travis.txt, tox
 wcwidth==0.1.9            # via -r requirements/quality.txt, pytest
 webencodings==0.5.1       # via -r requirements/quality.txt, bleach
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -7,12 +7,12 @@
 alabaster==0.7.12         # via sphinx
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-bleach==3.1.4             # via readme-renderer
-certifi==2019.11.28       # via -r requirements/test.txt, requests
+bleach==3.1.5             # via readme-renderer
+certifi==2020.4.5.1       # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 coreapi==2.3.3            # via -r requirements/test.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi, drf-yasg
-coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
+coverage==5.1             # via -r requirements/test.txt, pytest-cov
 django==2.2.12            # via -r requirements/test.txt, djangorestframework, drf-yasg
 djangorestframework==3.11.0  # via -r requirements/test.txt, drf-yasg
 doc8==0.8.0               # via -r requirements/doc.in
@@ -22,24 +22,24 @@ edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 idna==2.9                 # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
-inflection==0.3.1         # via -r requirements/test.txt, drf-yasg
-itypes==1.1.0             # via -r requirements/test.txt, coreapi
-jinja2==2.11.1            # via -r requirements/test.txt, coreschema, sphinx
+inflection==0.4.0         # via -r requirements/test.txt, drf-yasg
+itypes==1.2.0             # via -r requirements/test.txt, coreapi
+jinja2==2.11.2            # via -r requirements/test.txt, coreschema, sphinx
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 more-itertools==8.2.0     # via -r requirements/test.txt, pytest
-packaging==20.3           # via -r requirements/test.txt, drf-yasg, pytest, sphinx
+packaging==20.3           # via -r requirements/test.txt, bleach, drf-yasg, pytest, sphinx
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
-pbr==5.4.4                # via stevedore
+pbr==5.4.5                # via stevedore
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.8.1                 # via -r requirements/test.txt, pytest
 pygments==2.6.1           # via readme-renderer, sphinx
-pyparsing==2.4.6          # via -r requirements/test.txt, packaging
+pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
-pytz==2019.3              # via -r requirements/test.txt, babel, django
-readme-renderer==25.0     # via -r requirements/doc.in, twine
+pytz==2020.1              # via -r requirements/test.txt, babel, django
+readme-renderer==26.0     # via -r requirements/doc.in, twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.23.0          # via -r requirements/test.txt, coreapi, requests-toolbelt, sphinx, twine
 restructuredtext-lint==1.3.0  # via doc8
@@ -47,7 +47,7 @@ ruamel.yaml.clib==0.2.0   # via -r requirements/test.txt, ruamel.yaml
 ruamel.yaml==0.16.10      # via -r requirements/test.txt, drf-yasg
 six==1.14.0               # via -r requirements/test.txt, bleach, doc8, drf-yasg, edx-sphinx-theme, packaging, pathlib2, readme-renderer, stevedore
 snowballstemmer==2.0.0    # via sphinx
-sphinx==2.4.4             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.0.3             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -59,7 +59,7 @@ stevedore==1.32.0         # via doc8
 tqdm==4.45.0              # via twine
 twine==1.15.0             # via -r requirements/doc.in
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi, drf-yasg
-urllib3==1.25.8           # via -r requirements/test.txt, requests
+urllib3==1.25.9           # via -r requirements/test.txt, requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,9 @@
 #
 #    make upgrade
 #
-click==7.1.1              # via pip-tools
-pip-tools==4.5.1          # via -r requirements/pip-tools.in
+click==7.1.2              # via pip-tools
+pip-tools==5.1.0          # via -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,15 +8,15 @@ argparse==1.4.0           # via caniusepython3
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 backports.functools-lru-cache==1.6.1  # via caniusepython3
-bleach==3.1.4             # via readme-renderer
+bleach==3.1.5             # via readme-renderer
 caniusepython3==7.2.0     # via -r requirements/quality.in
-certifi==2019.11.28       # via -r requirements/test.txt, requests
+certifi==2020.4.5.1       # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
-click==7.1.1              # via click-log, edx-lint
+click==7.1.2              # via click-log, edx-lint
 coreapi==2.3.3            # via -r requirements/test.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi, drf-yasg
-coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
+coverage==5.1             # via -r requirements/test.txt, pytest-cov
 distlib==0.3.0            # via caniusepython3
 django==2.2.12            # via -r requirements/test.txt, djangorestframework, drf-yasg
 djangorestframework==3.11.0  # via -r requirements/test.txt, drf-yasg
@@ -25,15 +25,15 @@ drf-yasg==1.17.1          # via -r requirements/test.txt
 edx-lint==1.4.1           # via -r requirements/quality.in
 idna==2.9                 # via -r requirements/test.txt, requests
 importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
-inflection==0.3.1         # via -r requirements/test.txt, drf-yasg
+inflection==0.4.0         # via -r requirements/test.txt, drf-yasg
 isort==4.3.21             # via -r requirements/quality.in, pylint
-itypes==1.1.0             # via -r requirements/test.txt, coreapi
-jinja2==2.11.1            # via -r requirements/test.txt, coreschema
+itypes==1.2.0             # via -r requirements/test.txt, coreapi
+jinja2==2.11.2            # via -r requirements/test.txt, coreschema
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
 more-itertools==8.2.0     # via -r requirements/test.txt, pytest
-packaging==20.3           # via -r requirements/test.txt, caniusepython3, drf-yasg, pytest
+packaging==20.3           # via -r requirements/test.txt, bleach, caniusepython3, drf-yasg, pytest
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
@@ -45,12 +45,12 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.6          # via -r requirements/test.txt, packaging
+pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
-pytz==2019.3              # via -r requirements/test.txt, django
-readme-renderer==25.0     # via twine
+pytz==2020.1              # via -r requirements/test.txt, django
+readme-renderer==26.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.23.0          # via -r requirements/test.txt, caniusepython3, coreapi, requests-toolbelt, twine
 ruamel.yaml.clib==0.2.0   # via -r requirements/test.txt, ruamel.yaml
@@ -62,7 +62,7 @@ tqdm==4.45.0              # via twine
 twine==1.15.0             # via -r requirements/quality.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi, drf-yasg
-urllib3==1.25.8           # via -r requirements/test.txt, requests
+urllib3==1.25.9           # via -r requirements/test.txt, requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,34 +5,34 @@
 #    make upgrade
 #
 attrs==19.3.0             # via pytest
-certifi==2019.11.28       # via -r requirements/base.txt, requests
+certifi==2020.4.5.1       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
-coverage==5.0.4           # via pytest-cov
+coverage==5.1             # via pytest-cov
 drf-yasg==1.17.1          # via -r requirements/base.txt
 idna==2.9                 # via -r requirements/base.txt, requests
 importlib-metadata==1.6.0  # via pluggy, pytest
-inflection==0.3.1         # via -r requirements/base.txt, drf-yasg
-itypes==1.1.0             # via -r requirements/base.txt, coreapi
-jinja2==2.11.1            # via -r requirements/base.txt, coreschema
+inflection==0.4.0         # via -r requirements/base.txt, drf-yasg
+itypes==1.2.0             # via -r requirements/base.txt, coreapi
+jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 more-itertools==8.2.0     # via pytest
 packaging==20.3           # via -r requirements/base.txt, drf-yasg, pytest
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pyparsing==2.4.6          # via -r requirements/base.txt, packaging
+pyparsing==2.4.7          # via -r requirements/base.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.1             # via pytest-cov, pytest-django
-pytz==2019.3              # via -r requirements/base.txt, django
+pytz==2020.1              # via -r requirements/base.txt, django
 requests==2.23.0          # via -r requirements/base.txt, coreapi
 ruamel.yaml.clib==0.2.0   # via -r requirements/base.txt, ruamel.yaml
 ruamel.yaml==0.16.10      # via -r requirements/base.txt, drf-yasg
 six==1.14.0               # via -r requirements/base.txt, drf-yasg, packaging, pathlib2
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi, drf-yasg
-urllib3==1.25.8           # via -r requirements/base.txt, requests
+urllib3==1.25.9           # via -r requirements/base.txt, requests
 wcwidth==0.1.9            # via pytest
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,23 +5,23 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.22           # via -r requirements/travis.in
-coverage==5.0.4           # via codecov
+coverage==5.1             # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-resources==1.5.0  # via virtualenv
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 requests==2.23.0          # via codecov
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox==3.14.6               # via -r requirements/travis.in
-urllib3==1.25.8           # via requests
-virtualenv==20.0.15       # via tox
+urllib3==1.25.9           # via requests
+virtualenv==20.0.18       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -82,12 +82,12 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36}-django{111,20,21,22}-drf{39,latest}
+envlist = py35-django22-drf{39,latest},py38-django{22,30}-drf{latest}
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
@@ -8,10 +8,8 @@ norecursedirs = .* docs requirements
 
 [testenv]
 deps =
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     drf39: djangorestframework<3.10
     drflatest: djangorestframework
     -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
Add python 3.8 tests in travis. Modify tox.ini, only test in latest version of DRF, add classifiers for python 3.8

## Reviewers
- [x] @awais786 
- [ ] @ericfab179
- [ ] @jmbowman 
- [x] Ready for edX review