### PR TITLE
Demonstrate a difference in docstring treatment

### DIFF
--- a/example/views.py
+++ b/example/views.py
@@ -159,6 +159,23 @@ class HedgehogInfoView(GenericAPIView):
         Get information about the Hedgehog API.
 
         Returns a object with keys and values describing the API.
+
+        Args:
+            request: a Request.
+
+        """
+        raise EndpointNotImplemented()
+
+    def put(self, request):
+        """
+        Not really an endpoint at all, but has no @schema decorator.
+
+        This is to show the difference in treatment.  This is a second
+        paragraph which will be included in the docs.
+
+        Args:
+            request: a Request.
+
         """
         raise EndpointNotImplemented()
 

--- a/tests/expected_schema.json
+++ b/tests/expected_schema.json
@@ -231,7 +231,7 @@
         },
         "/hedgehog/v0/info": {
             "get": {
-                "description": "Returns a object with keys and values describing the API.",
+                "description": "Returns a object with keys and values describing the API.\n\nArgs:\n    request: a Request.",
                 "operationId": "hedgehog_v0_info_list",
                 "parameters": [],
                 "responses": {
@@ -244,7 +244,21 @@
                     "hedgehog"
                 ]
             },
-            "parameters": []
+            "parameters": [],
+            "put": {
+                "description": "This is to show the difference in treatment.  This is a second\nparagraph which will be included in the docs.",
+                "operationId": "hedgehog_v0_info_update",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "summary": "Not really an endpoint at all, but has no @schema decorator.",
+                "tags": [
+                    "hedgehog"
+                ]
+            }
         }
     },
     "produces": [


### PR DESCRIPTION
@kdmccormick This shows the difference in treatment of docstrings.

Without a `@schema` decorator, the docstring is trimmed of the "Args:" (and so on) sections.  This is due to logic in `AutoSchema._get_description_section` in django_rest_framework/schemas/inspectors.py .

With a `@schema` decorator, our code explicitly lifts the docstring and splits it in a more simplistic way to produce the summary and description.

Options:
1. Leave it as is.
2. Duplicate the code so that we strip the docstring the same way.
3. Give DRF a pull request that extracts the private self-less method into a function we can call.