### PR TITLE
Removed caniusepython3 from api-doc-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
       env: TOXENV=django22-drflatest
     - python: 3.8
       env: TOXENV=django22-drflatest
-    # Test quality in just Python 3.6.
-    - python: 3.6
+    # Test quality in just Python 3.5.
+    - python: 3.5
       env:
         - COMMAND="make quality"
         - PIPEXTRA="-r requirements/quality.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
       env: TOXENV=django22-drflatest
     - python: 3.8
       env: TOXENV=django22-drflatest
-    # Test quality in just Python 3.5.
-    - python: 3.5
+    # Test quality in just Python 3.6.
+    - python: 3.6
       env:
         - COMMAND="make quality"
         - PIPEXTRA="-r requirements/quality.txt"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+1.3.1 --- 2020-05-29
+--------------------
+
+* Removing caniusepython3 as it is no longer needed since python3 upgrade.
+
 1.3.0 --- 2020-04-30
 --------------------
 

--- a/edx_api_doc_tools/__init__.py
+++ b/edx_api_doc_tools/__init__.py
@@ -47,6 +47,6 @@ from .view_utils import (
 )
 
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 default_app_config = 'edx_api_doc_tools.apps.EdxApiDocToolsConfig'

--- a/pylintrc
+++ b/pylintrc
@@ -55,7 +55,7 @@
 [MASTER]
 ignore = migrations
 persistent = yes
-load-plugins = caniusepython3.pylint_checker,edx_lint.pylint,pylint_django,pylint_celery
+load-plugins = edx_lint.pylint,pylint_django,pylint_celery
 
 [MESSAGES CONTROL]
 enable = 

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -1,4 +1,4 @@
 # pylintrc tweaks for use with edx_lint.
 [MASTER]
 ignore = migrations
-load-plugins = caniusepython3.pylint_checker,edx_lint.pylint,pylint_django,pylint_celery
+load-plugins = edx_lint.pylint,pylint_django,pylint_celery

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,13 +16,13 @@ inflection==0.4.0         # via drf-yasg
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 markupsafe==1.1.1         # via jinja2
-packaging==20.3           # via drf-yasg
+packaging==20.4           # via drf-yasg
 pyparsing==2.4.7          # via packaging
 pytz==2020.1              # via django
 requests==2.23.0          # via coreapi
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via drf-yasg
-six==1.14.0               # via drf-yasg, packaging
+six==1.15.0               # via drf-yasg, packaging
 sqlparse==0.3.1           # via django
 uritemplate==3.0.1        # via coreapi, drf-yasg
 urllib3==1.25.9           # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,3 +7,6 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+
+# zipp 3.1.0 requires Python >= 3.6
+zipp<2.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,6 @@
 
 # zipp 3.1.0 requires Python >= 3.6
 zipp<2.0.0
+
+# keyring 21.2.1 requires Python >= 3.6
+keyring<=20.0.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,6 @@ zipp<2.0.0
 
 # keyring 21.2.1 requires Python >= 3.6
 keyring<=20.0.1
+
+# twine 1.15.0 requires Python >= 3.6
+twine<=1.15.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -79,7 +79,7 @@ virtualenv==20.0.21       # via -r requirements/travis.txt, tox
 wcwidth==0.1.9            # via -r requirements/quality.txt, pytest
 webencodings==0.5.1       # via -r requirements/quality.txt, bleach
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-zipp==3.1.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,14 +26,13 @@ edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, keyring, path, pluggy, pytest, tox, twine, virtualenv
+importlib-metadata==1.6.0  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, path, pluggy, pytest, tox, virtualenv
 inflect==4.1.0            # via jinja2-pluralize
 inflection==0.4.0         # via -r requirements/quality.txt, drf-yasg
 isort==4.3.21             # via -r requirements/quality.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, coreschema, diff-cover, jinja2-pluralize
-keyring==20.0.1           # via -c requirements/constraints.txt, -r requirements/quality.txt, twine
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
@@ -71,7 +70,7 @@ toml==0.10.1              # via -r requirements/travis.txt, tox
 tox-battery==0.6.1        # via -r requirements/dev.in
 tox==3.15.1               # via -r requirements/travis.txt, tox-battery
 tqdm==4.46.0              # via -r requirements/quality.txt, twine
-twine==3.1.1              # via -r requirements/quality.txt
+twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/quality.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/travis.txt, requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,7 +33,7 @@ isort==4.3.21             # via -r requirements/quality.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, coreschema, diff-cover, jinja2-pluralize
-keyring==21.2.1           # via -r requirements/quality.txt, twine
+keyring==20.0.1           # via -c requirements/constraints.txt, -r requirements/quality.txt, twine
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,53 +4,49 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via -r requirements/travis.txt, virtualenv
-argparse==1.4.0           # via -r requirements/quality.txt, caniusepython3
+appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/quality.txt, pytest
-backports.functools-lru-cache==1.6.1  # via -r requirements/quality.txt, caniusepython3
 bleach==3.1.5             # via -r requirements/quality.txt, readme-renderer
-caniusepython3==7.2.0     # via -r requirements/quality.txt
 certifi==2020.4.5.1       # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
-codecov==2.0.22           # via -r requirements/travis.txt
+codecov==2.1.3            # via -r requirements/travis.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/quality.txt, coreapi, drf-yasg
 coverage==5.1             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
 diff-cover==2.6.1         # via -r requirements/dev.in
-distlib==0.3.0            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
+distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
 django==2.2.12            # via -r requirements/quality.txt, djangorestframework, drf-yasg, edx-i18n-tools
 djangorestframework==3.11.0  # via -r requirements/quality.txt, drf-yasg
 docutils==0.16            # via -r requirements/quality.txt, readme-renderer
 drf-yasg==1.17.1          # via -r requirements/quality.txt
-edx-i18n-tools==0.5.0     # via -r requirements/dev.in
+edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 idna==2.9                 # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/travis.txt, virtualenv
-inflect==3.0.2            # via jinja2-pluralize
+importlib-metadata==1.6.0  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, keyring, path, pluggy, pytest, tox, twine, virtualenv
+inflect==4.1.0            # via jinja2-pluralize
 inflection==0.4.0         # via -r requirements/quality.txt, drf-yasg
 isort==4.3.21             # via -r requirements/quality.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, coreschema, diff-cover, jinja2-pluralize
+keyring==21.2.1           # via -r requirements/quality.txt, twine
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
-more-itertools==8.2.0     # via -r requirements/quality.txt, pytest
-packaging==20.3           # via -r requirements/quality.txt, -r requirements/travis.txt, bleach, caniusepython3, drf-yasg, pytest, tox
+more-itertools==8.3.0     # via -r requirements/quality.txt, pytest
+packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, bleach, drf-yasg, pytest, tox
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
-pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
-pip-tools==5.1.0          # via -r requirements/pip-tools.txt
+pip-tools==5.2.0          # via -r requirements/pip-tools.txt
 pkginfo==1.5.0.1          # via -r requirements/quality.txt, twine
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 py==1.8.1                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
-pycodestyle==2.5.0        # via -r requirements/quality.txt
+pycodestyle==2.6.0        # via -r requirements/quality.txt
 pydocstyle==5.0.2         # via -r requirements/quality.txt
 pygments==2.6.1           # via -r requirements/quality.txt, diff-cover, readme-renderer
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
@@ -58,32 +54,32 @@ pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
 pylint==2.4.2             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
-pytest-cov==2.8.1         # via -r requirements/quality.txt
+pytest-cov==2.9.0         # via -r requirements/quality.txt
 pytest-django==3.9.0      # via -r requirements/quality.txt
-pytest==5.4.1             # via -r requirements/quality.txt, pytest-cov, pytest-django
+pytest==5.4.2             # via -r requirements/quality.txt, pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/quality.txt, django
 pyyaml==5.3.1             # via edx-i18n-tools
 readme-renderer==26.0     # via -r requirements/quality.txt, twine
 requests-toolbelt==0.9.1  # via -r requirements/quality.txt, twine
-requests==2.23.0          # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, codecov, coreapi, requests-toolbelt, twine
+requests==2.23.0          # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, coreapi, requests-toolbelt, twine
 ruamel.yaml.clib==0.2.0   # via -r requirements/quality.txt, ruamel.yaml
 ruamel.yaml==0.16.10      # via -r requirements/quality.txt, drf-yasg
-six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, bleach, diff-cover, drf-yasg, edx-i18n-tools, edx-lint, packaging, pathlib2, pip-tools, readme-renderer, tox, virtualenv
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, bleach, diff-cover, drf-yasg, edx-i18n-tools, edx-lint, packaging, pip-tools, readme-renderer, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.3.1           # via -r requirements/quality.txt, django
-toml==0.10.0              # via -r requirements/travis.txt, tox
-tox-battery==0.5.2        # via -r requirements/dev.in
-tox==3.14.6               # via -r requirements/travis.txt, tox-battery
-tqdm==4.45.0              # via -r requirements/quality.txt, twine
-twine==1.15.0             # via -r requirements/quality.txt
+toml==0.10.1              # via -r requirements/travis.txt, tox
+tox-battery==0.6.1        # via -r requirements/dev.in
+tox==3.15.1               # via -r requirements/travis.txt, tox-battery
+tqdm==4.46.0              # via -r requirements/quality.txt, twine
+twine==3.1.1              # via -r requirements/quality.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 uritemplate==3.0.1        # via -r requirements/quality.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-virtualenv==20.0.18       # via -r requirements/travis.txt, tox
+virtualenv==20.0.21       # via -r requirements/travis.txt, tox
 wcwidth==0.1.9            # via -r requirements/quality.txt, pytest
 webencodings==0.5.1       # via -r requirements/quality.txt, bleach
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
+zipp==3.1.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -21,23 +21,23 @@ drf-yasg==1.17.1          # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 idna==2.9                 # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.6.0  # via -r requirements/test.txt, keyring, pluggy, pytest, twine
 inflection==0.4.0         # via -r requirements/test.txt, drf-yasg
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, coreschema, sphinx
+keyring==21.2.1           # via twine
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
-more-itertools==8.2.0     # via -r requirements/test.txt, pytest
-packaging==20.3           # via -r requirements/test.txt, bleach, drf-yasg, pytest, sphinx
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+more-itertools==8.3.0     # via -r requirements/test.txt, pytest
+packaging==20.4           # via -r requirements/test.txt, bleach, drf-yasg, pytest, sphinx
 pbr==5.4.5                # via stevedore
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.8.1                 # via -r requirements/test.txt, pytest
 pygments==2.6.1           # via readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-cov==2.9.0         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/test.txt, babel, django
 readme-renderer==26.0     # via -r requirements/doc.in, twine
 requests-toolbelt==0.9.1  # via twine
@@ -45,9 +45,9 @@ requests==2.23.0          # via -r requirements/test.txt, coreapi, requests-tool
 restructuredtext-lint==1.3.0  # via doc8
 ruamel.yaml.clib==0.2.0   # via -r requirements/test.txt, ruamel.yaml
 ruamel.yaml==0.16.10      # via -r requirements/test.txt, drf-yasg
-six==1.14.0               # via -r requirements/test.txt, bleach, doc8, drf-yasg, edx-sphinx-theme, packaging, pathlib2, readme-renderer, stevedore
+six==1.15.0               # via -r requirements/test.txt, bleach, doc8, drf-yasg, edx-sphinx-theme, packaging, readme-renderer, stevedore
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.3             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.0.4             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -56,13 +56,13 @@ sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via doc8
-tqdm==4.45.0              # via twine
-twine==1.15.0             # via -r requirements/doc.in
+tqdm==4.46.0              # via twine
+twine==3.1.1              # via -r requirements/doc.in
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/test.txt, requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
-zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
+zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -25,7 +25,7 @@ importlib-metadata==1.6.0  # via -r requirements/test.txt, keyring, pluggy, pyte
 inflection==0.4.0         # via -r requirements/test.txt, drf-yasg
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, coreschema, sphinx
-keyring==21.2.1           # via twine
+keyring==20.0.1           # via -c requirements/constraints.txt, twine
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 more-itertools==8.3.0     # via -r requirements/test.txt, pytest
 packaging==20.4           # via -r requirements/test.txt, bleach, drf-yasg, pytest, sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -21,11 +21,10 @@ drf-yasg==1.17.1          # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 idna==2.9                 # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via -r requirements/test.txt, keyring, pluggy, pytest, twine
+importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
 inflection==0.4.0         # via -r requirements/test.txt, drf-yasg
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, coreschema, sphinx
-keyring==20.0.1           # via -c requirements/constraints.txt, twine
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 more-itertools==8.3.0     # via -r requirements/test.txt, pytest
 packaging==20.4           # via -r requirements/test.txt, bleach, drf-yasg, pytest, sphinx
@@ -57,7 +56,7 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via doc8
 tqdm==4.46.0              # via twine
-twine==3.1.1              # via -r requirements/doc.in
+twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/doc.in
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/test.txt, requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -62,7 +62,7 @@ uritemplate==3.0.1        # via -r requirements/test.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/test.txt, requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
-zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.0          # via -r requirements/pip-tools.in
-six==1.14.0               # via pip-tools
+pip-tools==5.2.0          # via -r requirements/pip-tools.in
+six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -3,7 +3,6 @@
 
 -r test.txt               # Core and testing dependencies for this package
 
-caniusepython3            # Additional Python 3 compatibility pylint checks
 edx-lint                  # edX pylint rules and plugins
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,12 +4,9 @@
 #
 #    make upgrade
 #
-argparse==1.4.0           # via caniusepython3
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
-backports.functools-lru-cache==1.6.1  # via caniusepython3
 bleach==3.1.5             # via readme-renderer
-caniusepython3==7.2.0     # via -r requirements/quality.in
 certifi==2020.4.5.1       # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
@@ -17,28 +14,27 @@ click==7.1.2              # via click-log, edx-lint
 coreapi==2.3.3            # via -r requirements/test.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi, drf-yasg
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
-distlib==0.3.0            # via caniusepython3
 django==2.2.12            # via -r requirements/test.txt, djangorestframework, drf-yasg
 djangorestframework==3.11.0  # via -r requirements/test.txt, drf-yasg
 docutils==0.16            # via readme-renderer
 drf-yasg==1.17.1          # via -r requirements/test.txt
 edx-lint==1.4.1           # via -r requirements/quality.in
 idna==2.9                 # via -r requirements/test.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.6.0  # via -r requirements/test.txt, keyring, pluggy, pytest, twine
 inflection==0.4.0         # via -r requirements/test.txt, drf-yasg
 isort==4.3.21             # via -r requirements/quality.in, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, coreschema
+keyring==21.2.1           # via twine
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
-more-itertools==8.2.0     # via -r requirements/test.txt, pytest
-packaging==20.3           # via -r requirements/test.txt, bleach, caniusepython3, drf-yasg, pytest
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+more-itertools==8.3.0     # via -r requirements/test.txt, pytest
+packaging==20.4           # via -r requirements/test.txt, bleach, drf-yasg, pytest
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.8.1                 # via -r requirements/test.txt, pytest
-pycodestyle==2.5.0        # via -r requirements/quality.in
+pycodestyle==2.6.0        # via -r requirements/quality.in
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pygments==2.6.1           # via readme-renderer
 pylint-celery==0.3        # via edx-lint
@@ -46,27 +42,27 @@ pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-cov==2.9.0         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/test.txt, django
 readme-renderer==26.0     # via twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.23.0          # via -r requirements/test.txt, caniusepython3, coreapi, requests-toolbelt, twine
+requests==2.23.0          # via -r requirements/test.txt, coreapi, requests-toolbelt, twine
 ruamel.yaml.clib==0.2.0   # via -r requirements/test.txt, ruamel.yaml
 ruamel.yaml==0.16.10      # via -r requirements/test.txt, drf-yasg
-six==1.14.0               # via -r requirements/test.txt, astroid, bleach, drf-yasg, edx-lint, packaging, pathlib2, readme-renderer
+six==1.15.0               # via -r requirements/test.txt, astroid, bleach, drf-yasg, edx-lint, packaging, readme-renderer
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via -r requirements/test.txt, django
-tqdm==4.45.0              # via twine
-twine==1.15.0             # via -r requirements/quality.in
+tqdm==4.46.0              # via twine
+twine==3.1.1              # via -r requirements/quality.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/test.txt, requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via astroid
-zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
+zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -25,7 +25,7 @@ inflection==0.4.0         # via -r requirements/test.txt, drf-yasg
 isort==4.3.21             # via -r requirements/quality.in, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, coreschema
-keyring==21.2.1           # via twine
+keyring==20.0.1           # via -c requirements/constraints.txt, twine
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -20,12 +20,11 @@ docutils==0.16            # via readme-renderer
 drf-yasg==1.17.1          # via -r requirements/test.txt
 edx-lint==1.4.1           # via -r requirements/quality.in
 idna==2.9                 # via -r requirements/test.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/test.txt, keyring, pluggy, pytest, twine
+importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
 inflection==0.4.0         # via -r requirements/test.txt, drf-yasg
 isort==4.3.21             # via -r requirements/quality.in, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jinja2==2.11.2            # via -r requirements/test.txt, coreschema
-keyring==20.0.1           # via -c requirements/constraints.txt, twine
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
@@ -55,7 +54,7 @@ six==1.15.0               # via -r requirements/test.txt, astroid, bleach, drf-y
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 tqdm==4.46.0              # via twine
-twine==3.1.1              # via -r requirements/quality.in
+twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/quality.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/test.txt, requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -62,7 +62,7 @@ urllib3==1.25.9           # via -r requirements/test.txt, requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via astroid
-zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,22 +17,21 @@ inflection==0.4.0         # via -r requirements/base.txt, drf-yasg
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-more-itertools==8.2.0     # via pytest
-packaging==20.3           # via -r requirements/base.txt, drf-yasg, pytest
-pathlib2==2.3.5           # via pytest
+more-itertools==8.3.0     # via pytest
+packaging==20.4           # via -r requirements/base.txt, drf-yasg, pytest
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
-pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-cov==2.9.0         # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.1             # via pytest-cov, pytest-django
+pytest==5.4.2             # via pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/base.txt, django
 requests==2.23.0          # via -r requirements/base.txt, coreapi
 ruamel.yaml.clib==0.2.0   # via -r requirements/base.txt, ruamel.yaml
 ruamel.yaml==0.16.10      # via -r requirements/base.txt, drf-yasg
-six==1.14.0               # via -r requirements/base.txt, drf-yasg, packaging, pathlib2
+six==1.15.0               # via -r requirements/base.txt, drf-yasg, packaging
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/base.txt, requests
 wcwidth==0.1.9            # via pytest
-zipp==1.2.0               # via importlib-metadata
+zipp==3.1.0               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -34,4 +34,4 @@ sqlparse==0.3.1           # via -r requirements/base.txt, django
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/base.txt, requests
 wcwidth==0.1.9            # via pytest
-zipp==3.1.0               # via importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,24 +4,23 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via virtualenv
+appdirs==1.4.4            # via virtualenv
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.22           # via -r requirements/travis.in
+codecov==2.1.3            # via -r requirements/travis.in
 coverage==5.1             # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
-packaging==20.3           # via tox
+importlib-metadata==1.6.0  # via pluggy, tox, virtualenv
+packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.7          # via packaging
 requests==2.23.0          # via codecov
-six==1.14.0               # via packaging, tox, virtualenv
-toml==0.10.0              # via tox
-tox==3.14.6               # via -r requirements/travis.in
+six==1.15.0               # via packaging, tox, virtualenv
+toml==0.10.1              # via tox
+tox==3.15.1               # via -r requirements/travis.in
 urllib3==1.25.9           # via requests
-virtualenv==20.0.18       # via tox
-zipp==1.2.0               # via importlib-metadata, importlib-resources
+virtualenv==20.0.21       # via tox
+zipp==3.1.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -23,4 +23,4 @@ toml==0.10.1              # via tox
 tox==3.15.1               # via -r requirements/travis.in
 urllib3==1.25.9           # via requests
 virtualenv==20.0.21       # via tox
-zipp==3.1.0               # via importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata


### PR DESCRIPTION
**Description:** Removing caniusepython3 from api-doc-tools

**JIRA:** https://openedx.atlassian.net/browse/BOM-1664

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
