### PR TITLE
#27 Generate documentation for views that are under different root paths

### DIFF
--- a/docs/adding.rst
+++ b/docs/adding.rst
@@ -14,6 +14,18 @@ Next, add the following to your list of installed apps in Django settings::
         edx_api_doc_tools,
     )
 
+You can specify the prefixes of the views whose documentation you want to generate.
+To achieve this, add the root paths to the settings file as follows::
+
+    EDX_API_DOC_TOOLS_PREFIXES = [
+        "/api/",
+        "/root2/",
+        "/root3/",
+    ]
+
+Note that if no prefix is added to the list, by default the documentation will
+be generated for views under the root path ``/api``.
+
 Then, in ``urls.py``::
 
     ...
@@ -23,10 +35,8 @@ Then, in ``urls.py``::
     urlpatterns += make_docs_urls(api_info)
 
 
-Your should now be able to load the Swagger UI in a browser at
-`https://${your_service}/api-docs`.  Note that by default, documentation is
-only generated for views under the root path ``/api``.  Generation for other
-views is possible but requires some extra configuration.
+You should now be able to load the Swagger UI in a browser at
+`https://${your_service}/api-docs`.
 
 Finally, you can enrich the generated documentation::
 

--- a/edx_api_doc_tools/conf_utils.py
+++ b/edx_api_doc_tools/conf_utils.py
@@ -160,15 +160,28 @@ class ApiSchemaGenerator(OpenAPISchemaGenerator):
         """
         Return dict of endpoints to be displayed.
         """
+        prefixes = get_endpoints_prefixes()
         endpoints = super(ApiSchemaGenerator, self).get_endpoints(request)
-        subpoints = {p: v for p, v in endpoints.items() if p.startswith("/api/")}
+        subpoints = {p: v for p, v in endpoints.items() if p.startswith(prefixes)}
         return subpoints
 
     def determine_path_prefix(self, paths):
         """
         Return common prefix for all paths.
         """
-        return "/api/"
+        return "/"
+
+
+def get_endpoints_prefixes():
+    """
+    Return the root paths of the endpoints to be displayed.
+    """
+    if getattr(settings, "EDX_API_DOC_TOOLS_PREFIXES", []) and \
+            isinstance(settings.EDX_API_DOC_TOOLS_PREFIXES, list):
+        prefixes = tuple(settings.EDX_API_DOC_TOOLS_PREFIXES)
+    else:
+        prefixes = "/api/"
+    return prefixes
 
 
 def get_docs_cache_timeout():

--- a/example/urls.py
+++ b/example/urls.py
@@ -24,6 +24,8 @@ urlpatterns += ROUTER.urls
 urlpatterns += [
     url(r'/api/hedgehog/v0/info', HedgehogInfoView.as_view()),
     url(r'/api/hedgehog/v0/undoc-view', HedgehogUndocumentedView.as_view()),
+    url(r'/api/hedgehog/v1/info', HedgehogInfoView.as_view()),
+    url(r'/api/hedgehog/v1/undoc-view', HedgehogUndocumentedView.as_view()),
 ]
 
 urlpatterns += make_docs_urls(

--- a/tests/expected_schema.json
+++ b/tests/expected_schema.json
@@ -1,5 +1,5 @@
 {
-    "basePath": "/api",
+    "basePath": "/",
     "consumes": [
         "application/json"
     ],
@@ -67,10 +67,10 @@
         "version": "v0"
     },
     "paths": {
-        "/hedgehog/v0/hogs/": {
+        "/api/hedgehog/v0/hogs/": {
             "get": {
                 "description": "Hedgehogs can be filtered by minimum weight (grams or ounces),\ntheir favorite food, whether they graduated college,\nor any combination of those criterion.",
-                "operationId": "hedgehog_v0_hogs_list",
+                "operationId": "api_hedgehog_v0_hogs_list",
                 "parameters": [
                     {
                         "description": "Filter on whether minimum weight (grams).",
@@ -113,13 +113,13 @@
                 },
                 "summary": "Fetch the list of edX hedgehogs.",
                 "tags": [
-                    "hedgehog"
+                    "api"
                 ]
             },
             "parameters": [],
             "post": {
                 "description": "If successful, an absolute URI for the hedgehog is returned in the\n'Location' HTTP response header.",
-                "operationId": "hedgehog_v0_hogs_create",
+                "operationId": "api_hedgehog_v0_hogs_create",
                 "parameters": [
                     {
                         "in": "body",
@@ -156,14 +156,14 @@
                 },
                 "summary": "Create a new hedgehog.",
                 "tags": [
-                    "hedgehog"
+                    "api"
                 ]
             }
         },
-        "/hedgehog/v0/hogs/{hedgehog_key}/": {
+        "/api/hedgehog/v0/hogs/{hedgehog_key}/": {
             "delete": {
                 "description": "Wipe a hedgehog from the database.",
-                "operationId": "hedgehog_v0_hogs_delete",
+                "operationId": "api_hedgehog_v0_hogs_delete",
                 "parameters": [
                     {
                         "description": "Key identifying the hog. Lowercase letters only.",
@@ -189,12 +189,12 @@
                 },
                 "summary": "Wipe a hedgehog from the database.",
                 "tags": [
-                    "hedgehog"
+                    "api"
                 ]
             },
             "get": {
                 "description": "Fetch details for a _single_ hedgehog by key.",
-                "operationId": "hedgehog_v0_hogs_read",
+                "operationId": "api_hedgehog_v0_hogs_read",
                 "parameters": [
                     {
                         "description": "Key identifying the hog. Lowercase letters only.",
@@ -217,7 +217,7 @@
                 },
                 "summary": "Fetch details for a _single_ hedgehog by key.",
                 "tags": [
-                    "hedgehog"
+                    "api"
                 ]
             },
             "parameters": [
@@ -229,10 +229,10 @@
                 }
             ]
         },
-        "/hedgehog/v0/info": {
+        "/api/hedgehog/v0/info": {
             "get": {
                 "description": "Returns a object with keys and values describing the API.\n\nArgs:\n    request: a Request.",
-                "operationId": "hedgehog_v0_info_list",
+                "operationId": "api_hedgehog_v0_info_list",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -241,13 +241,13 @@
                 },
                 "summary": "Get information about the Hedgehog API.",
                 "tags": [
-                    "hedgehog"
+                    "api"
                 ]
             },
             "parameters": [],
             "put": {
                 "description": "This is to show the difference in treatment.  This is a second\nparagraph which will be included in the docs.",
-                "operationId": "hedgehog_v0_info_update",
+                "operationId": "api_hedgehog_v0_info_update",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -256,7 +256,38 @@
                 },
                 "summary": "Not really an endpoint at all, but has no @schema decorator.",
                 "tags": [
-                    "hedgehog"
+                    "api"
+                ]
+            }
+        },
+        "/api/hedgehog/v1/info": {
+            "get": {
+                "description": "Returns a object with keys and values describing the API.\n\nArgs:\n    request: a Request.",
+                "operationId": "api_hedgehog_v1_info_list",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "summary": "Get information about the Hedgehog API.",
+                "tags": [
+                    "api"
+                ]
+            },
+            "parameters": [],
+            "put": {
+                "description": "This is to show the difference in treatment.  This is a second\nparagraph which will be included in the docs.",
+                "operationId": "api_hedgehog_v1_info_update",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "summary": "Not really an endpoint at all, but has no @schema decorator.",
+                "tags": [
+                    "api"
                 ]
             }
         }

--- a/tests/test_doc_tools.py
+++ b/tests/test_doc_tools.py
@@ -87,6 +87,22 @@ class DocViewTests(SimpleTestCase):
         actual = json.loads(ui_data_response.content.decode('utf-8'))
         assert actual == expected
 
+    def test_default_prefix(self):
+        """
+        Test case when the attribute prefix is the default.
+        """
+        with override_settings(EDX_API_DOC_TOOLS_PREFIXES="api/hedgehog/v1/"):
+            response = self.client.get('/api-docs/')
+            assert response.status_code == 200
+
+    def test_settings_prefixes(self):
+        """
+        Test case when the prefixes are declare in the settings.
+        """
+        with override_settings(EDX_API_DOC_TOOLS_PREFIXES=["/enterprise/"]):
+            response = self.client.get('/api-docs/')
+            assert response.status_code == 200
+
 
 @pytest.mark.parametrize("docstring, summary, description", [
     (None, None, None),


### PR DESCRIPTION
**Description:** This PR resolves #27 . It allows to configure in Django settings the root paths of the services whose documentation is to be generated.

- Modified ApiSchemaGenerator so that it takes the prefixes from the settings and returns the proper endpoints. File: edx_api_doc_tools/conf_utils.py.

- Added get_endpoints_prefixes() method to return the prefixes from Django settings, in case no root paths were declared returns “/api/” as the default prefix. File: edx_api_doc_tools/conf_utils.py.

- Updated the reference schema with the new generated schema so the test get_data_view() passes and the actual schema equals the reference schema. File: tests/expected_schema.json.

- Added the explanation of how to specify the root paths in the settings file. File: docs/adding.rst.


@felipemontoya
@mariajgrimaldi
@morenol 