### PR TITLE
Add argument for specifying url patterns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+1.3.2 --- 2020-09-23
+____________________
+
+* Adding option to specify url patterns for generated docs.
+
 1.3.1 --- 2020-05-29
 --------------------
 

--- a/docs/excluding.rst
+++ b/docs/excluding.rst
@@ -86,3 +86,31 @@ For example::
             """
             Nor will this.
             """
+
+Additionally, api-docs can be generated only for specified URL patterns. This also
+allows documentation for endpoints outside of the ``/api/`` path.
+
+The following code will result in generated documentation only for the ``/test/hedgehog/v1/info`` endpoint::
+
+    urlpatterns = []
+
+    urlpatterns += [
+        url(r'/api/hedgehog/v1/info', HedgehogInfoView.as_view()),
+        url(r'/api/hedgehog/v1/undoc-view', HedgehogUndocumentedView.as_view()),
+        url(r'/test/hedgehog/v1/info', HedgehogInfoView.as_view()),
+        url(r'/test/hedgehog/v1/undoc-view', HedgehogUndocumentedView.as_view()),
+    ]
+
+    display_urls = [
+        url(r'/test/hedgehog/v1/info', HedgehogInfoView.as_view()),
+    ]
+
+    urlpatterns += make_docs_urls(
+        make_api_info(
+            title="edX Hedgehog Service API",
+            version="v1",
+            email="hedgehog-support@example.com",
+            description="A REST API for interacting with the edX hedgehog service.",
+        ),
+        api_url_patterns=display_urls,
+    )

--- a/edx_api_doc_tools/__init__.py
+++ b/edx_api_doc_tools/__init__.py
@@ -46,6 +46,6 @@ from .view_utils import (
 )
 
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 default_app_config = 'edx_api_doc_tools.apps.EdxApiDocToolsConfig'

--- a/example/urls_with_pattern.py
+++ b/example/urls_with_pattern.py
@@ -1,0 +1,33 @@
+"""
+REST API URLs for testing make_docs_urls with url pattern specified.
+"""
+
+from django.conf.urls import url
+
+from edx_api_doc_tools import make_api_info, make_docs_urls
+
+from .views import HedgehogInfoView, HedgehogUndocumentedView
+
+
+urlpatterns = []
+
+urlpatterns += [
+    url(r'/api/hedgehog/v1/info', HedgehogInfoView.as_view()),
+    url(r'/api/hedgehog/v1/undoc-view', HedgehogUndocumentedView.as_view()),
+    url(r'/test/hedgehog/v1/info', HedgehogInfoView.as_view()),
+    url(r'/test/hedgehog/v1/undoc-view', HedgehogUndocumentedView.as_view()),
+]
+
+display_urls = [
+    url(r'/test/hedgehog/v1/info', HedgehogInfoView.as_view()),
+]
+
+urlpatterns += make_docs_urls(
+    make_api_info(
+        title="edX Hedgehog Service API",
+        version="v1",
+        email="hedgehog-support@example.com",
+        description="A REST API for interacting with the edX hedgehog service.",
+    ),
+    api_url_patterns=display_urls,
+)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 actual_schema.json
+actual_schema_with_patterns.json

--- a/tests/expected_schema_with_patterns.json
+++ b/tests/expected_schema_with_patterns.json
@@ -1,0 +1,66 @@
+{
+    "basePath": "/test/hedgehog/v1",
+    "consumes": [
+        "application/json"
+    ],
+    "definitions": {},
+    "host": "testserver",
+    "info": {
+        "contact": {
+            "email": "hedgehog-support@example.com"
+        },
+        "description": "A REST API for interacting with the edX hedgehog service.",
+        "title": "edX Hedgehog Service API",
+        "version": "v1"
+    },
+    "paths": {
+        "/info": {
+            "get": {
+                "description": "Returns a object with keys and values describing the API.\n\nArgs:\n    request: a Request.",
+                "operationId": "info_list",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "summary": "Get information about the Hedgehog API.",
+                "tags": [
+                    "info"
+                ]
+            },
+            "parameters": [],
+            "put": {
+                "description": "This is to show the difference in treatment.  This is a second\nparagraph which will be included in the docs.",
+                "operationId": "info_update",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "summary": "Not really an endpoint at all, but has no @schema decorator.",
+                "tags": [
+                    "info"
+                ]
+            }
+        }
+    },
+    "produces": [
+        "application/json"
+    ],
+    "schemes": [
+        "http"
+    ],
+    "security": [
+        {
+            "Basic": []
+        }
+    ],
+    "securityDefinitions": {
+        "Basic": {
+            "type": "basic"
+        }
+    },
+    "swagger": "2.0"
+}


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

**Description:** This PR allows users of this repository the option to specify which url patterns they want api docs generated for. This is especially useful for apis that have different versions, and only one version should be displayed. 

This also allows users to generate api docs for different base paths, as "/api" is not the default if patterns are specified. This can be seen in urls_with_patterns.py.

**JIRA:** [MST-201](https://openedx.atlassian.net/browse/MST-201)

**Dependencies:** Will link to registrar PR when that is up.

**Merge deadline:** None

**Installation instructions:** None

**Testing instructions:**

1. Updated expected_schema for limited url view. Also works as expected when no url_pattern is given. 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
