### PR TITLE
Add optional body parameter to schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ matrix:
     - python: 3.5
       env: TOXENV=django22-drf39 AFTER_SUCCESS=codecov
     - python: 3.5
-      env: TOXENV=django22-drflatest
+      env: TOXENV=django22-drf311
     - python: 3.8
-      env: TOXENV=django22-drflatest
+      env: TOXENV=django22-drf311
     # Test quality in just Python 3.5.
     - python: 3.5
       env:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ----------
 
+1.3.3 --- 2020-10-05
+____________________
+
+* Adding option to include a body parameter in requests.
+* Travis build uses djangorestframework<3.12 as drf-yasg is currently incompatible with 3.12.
+
 1.3.2 --- 2020-09-23
 ____________________
 

--- a/edx_api_doc_tools/__init__.py
+++ b/edx_api_doc_tools/__init__.py
@@ -46,6 +46,6 @@ from .view_utils import (
 )
 
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'
 
 default_app_config = 'edx_api_doc_tools.apps.EdxApiDocToolsConfig'

--- a/edx_api_doc_tools/view_utils.py
+++ b/edx_api_doc_tools/view_utils.py
@@ -102,6 +102,7 @@ def exclude_schema_for_all(view_class):
 
 
 def schema(
+    body=None,
     parameters=None,
     responses=None,
     summary=None,
@@ -114,6 +115,8 @@ def schema(
     description fields should be in Markdown and will be automatically dedented.
 
     Arguments:
+        body: Optional payload used for POST, PUT, and PATCH requests.
+            Accepts a serializer class.
         parameters (list[openapi.Parameter]): Optional list of parameters to
             the API endpoint.
         responses (dict[int, object]): Optional map from HTTP statuses to either:
@@ -125,6 +128,7 @@ def schema(
             If None, we attempt to extract it from the first line of the docstring.
         description (str): Optional multi-line description of operation.
             If None, we attempt to extract it from the rest of the docstring.
+        request_body (Serializer): Optional serializer class corresponding to the body of the request.
     """
     for param in parameters or ():
         param.description = dedent(param.description)
@@ -137,6 +141,7 @@ def schema(
         final_summary = summary or docstring_summary
         final_description = description or docstring_description or final_summary
         return swagger_auto_schema(
+            request_body=body,
             manual_parameters=parameters,
             responses=responses,
             operation_summary=final_summary,

--- a/example/views.py
+++ b/example/views.py
@@ -165,12 +165,27 @@ class HedgehogInfoView(GenericAPIView):
         """
         raise EndpointNotImplemented()
 
-    def put(self, request):
+    def delete(self, request):
         """
         Not really an endpoint at all, but has no @schema decorator.
 
         This is to show the difference in treatment.  This is a second
         paragraph which will be included in the docs.
+
+        Args:
+            request: a Request.
+
+        """
+        raise EndpointNotImplemented()
+
+    @schema(
+        body=HedgehogSerializer
+    )
+    def put(self, request):
+        """
+        Not really an endpoint at all, but specifies body parameter.
+
+        This is to show the body parameter can be used.
 
         Args:
             request: a Request.

--- a/tests/expected_schema.json
+++ b/tests/expected_schema.json
@@ -230,6 +230,20 @@
             ]
         },
         "/hedgehog/v0/info": {
+            "delete": {
+                "description": "This is to show the difference in treatment.  This is a second\nparagraph which will be included in the docs.",
+                "operationId": "hedgehog_v0_info_delete",
+                "parameters": [],
+                "responses": {
+                    "204": {
+                        "description": ""
+                    }
+                },
+                "summary": "Not really an endpoint at all, but has no @schema decorator.",
+                "tags": [
+                    "hedgehog"
+                ]
+            },
             "get": {
                 "description": "Returns a object with keys and values describing the API.\n\nArgs:\n    request: a Request.",
                 "operationId": "hedgehog_v0_info_list",
@@ -246,15 +260,27 @@
             },
             "parameters": [],
             "put": {
-                "description": "This is to show the difference in treatment.  This is a second\nparagraph which will be included in the docs.",
+                "description": "This is to show the body parameter can be used.\n\nArgs:\n    request: a Request.",
                 "operationId": "hedgehog_v0_info_update",
-                "parameters": [],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "data",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": ""
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }
                     }
                 },
-                "summary": "Not really an endpoint at all, but has no @schema decorator.",
+                "summary": "Not really an endpoint at all, but specifies body parameter.",
                 "tags": [
                     "hedgehog"
                 ]

--- a/tests/expected_schema_with_patterns.json
+++ b/tests/expected_schema_with_patterns.json
@@ -3,7 +3,60 @@
     "consumes": [
         "application/json"
     ],
-    "definitions": {},
+    "definitions": {
+        "Hedgehog": {
+            "properties": {
+                "fav_food": {
+                    "enum": [
+                        "critters",
+                        "crawlies",
+                        "strawberries"
+                    ],
+                    "title": "Fav food",
+                    "type": "string"
+                },
+                "is_college_graduate": {
+                    "default": false,
+                    "title": "Is college graduate",
+                    "type": "boolean"
+                },
+                "key": {
+                    "format": "slug",
+                    "minLength": 1,
+                    "pattern": "^[-a-zA-Z0-9_]+$",
+                    "title": "Key",
+                    "type": "string"
+                },
+                "name": {
+                    "minLength": 1,
+                    "title": "Name",
+                    "type": "string"
+                },
+                "uuid": {
+                    "format": "uuid",
+                    "title": "Uuid",
+                    "type": "string"
+                },
+                "weight_grams": {
+                    "title": "Weight grams",
+                    "type": "integer"
+                },
+                "weight_ounces": {
+                    "readOnly": true,
+                    "title": "Weight ounces",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "uuid",
+                "key",
+                "name",
+                "weight_grams",
+                "fav_food"
+            ],
+            "type": "object"
+        }
+    },
     "host": "testserver",
     "info": {
         "contact": {
@@ -15,6 +68,20 @@
     },
     "paths": {
         "/info": {
+            "delete": {
+                "description": "This is to show the difference in treatment.  This is a second\nparagraph which will be included in the docs.",
+                "operationId": "info_delete",
+                "parameters": [],
+                "responses": {
+                    "204": {
+                        "description": ""
+                    }
+                },
+                "summary": "Not really an endpoint at all, but has no @schema decorator.",
+                "tags": [
+                    "info"
+                ]
+            },
             "get": {
                 "description": "Returns a object with keys and values describing the API.\n\nArgs:\n    request: a Request.",
                 "operationId": "info_list",
@@ -31,15 +98,27 @@
             },
             "parameters": [],
             "put": {
-                "description": "This is to show the difference in treatment.  This is a second\nparagraph which will be included in the docs.",
+                "description": "This is to show the body parameter can be used.\n\nArgs:\n    request: a Request.",
                 "operationId": "info_update",
-                "parameters": [],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "data",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": ""
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }
                     }
                 },
-                "summary": "Not really an endpoint at all, but has no @schema decorator.",
+                "summary": "Not really an endpoint at all, but specifies body parameter.",
                 "tags": [
                     "info"
                 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35-django22-drf{39,latest},py38-django{22,30}-drf{latest}
+envlist = py35-django22-drf{39,311,latest},py38-django{22,30}-drf{311,latest}
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
@@ -11,6 +11,7 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     drf39: djangorestframework<3.10
+    drf311: djangorestframework<3.12
     drflatest: djangorestframework
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
**Description:** Adds body parameter to schema in order to allow for POST, PUT, and PATCH endpoints.

**JIRA:** [MST-203](https://openedx.atlassian.net/browse/MST-203)

Example of what body parameter will output:

<img width="1142" alt="Screen Shot 2020-10-05 at 10 50 29 AM" src="https://user-images.githubusercontent.com/46360176/95095203-c283b680-06f8-11eb-8ebd-8169ce3b4e39.png">

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
