### PR TITLE
Updated the travis badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+1.4.1 --- 2020-11-20
+--------------------
+
+* Updated the travis-badge in README.rst to point to travis-ci.com
+
 1.4.0 --- 2020-10-05
 --------------------
 

--- a/README.rst
+++ b/README.rst
@@ -80,8 +80,8 @@ Have a question about this repository, or about the Open edX project in general?
 .. |pypi| image:: https://img.shields.io/pypi/v/edx-api-doc-tools.svg
     :target: https://pypi.python.org/pypi/edx-api-doc-tools/
     :alt: PyPI
-.. |travis| image:: https://travis-ci.org/edx/api-doc-tools.svg?branch=master
-    :target: https://travis-ci.org/edx/api-doc-tools
+.. |travis| image:: https://travis-ci.com/edx/api-doc-tools.svg?branch=master
+    :target: https://travis-ci.com/edx/api-doc-tools
     :alt: Travis
 .. |codecov| image:: http://codecov.io/github/edx/api-doc-tools/coverage.svg?branch=master
     :target: http://codecov.io/github/edx/api-doc-tools?branch=master

--- a/edx_api_doc_tools/__init__.py
+++ b/edx_api_doc_tools/__init__.py
@@ -46,6 +46,6 @@ from .view_utils import (
 )
 
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 default_app_config = 'edx_api_doc_tools.apps.EdxApiDocToolsConfig'


### PR DESCRIPTION
Updated the README file.
Travis badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'
JIRA: https://openedx.atlassian.net/browse/BOM-2089