### PR TITLE
build: disable a pylint check we don't need

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,10 @@ import sys
 from setuptools import setup
 
 
+# We open files with one-line shorthands, it's ok.
+# pylint: disable=consider-using-with
+
+
 def get_version(*file_paths):
     """
     Extract the version string from the file at the given relative path fragments.


### PR DESCRIPTION
This new violation was because pylint updated in the last "make upgrade".

TBH, I don't like this boilerplate code in setup.py to begin with, but
that's for another day.

**Description:** Describe in a couple of sentences what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
