### PR TITLE
django constraint in base.in giving conflicting issues in other packages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,12 @@ Change Log
 Unreleased
 ----------
 
-1.4.2 --- 2021-12-08
+1.4.3 --- 2021-07-15
+--------------------
+
+* Removed Django constraints from base.in
+
+1.4.2 --- 2021-01-08
 --------------------
 
 * Dropped python3.5 support.

--- a/edx_api_doc_tools/__init__.py
+++ b/edx_api_doc_tools/__init__.py
@@ -46,6 +46,6 @@ from .view_utils import (
 )
 
 
-__version__ = '1.4.2'
+__version__ = '1.4.3'
 
 default_app_config = 'edx_api_doc_tools.apps.EdxApiDocToolsConfig'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Core requirements for using this application
 -c constraints.txt
 
-Django>=1.11,<3.0
+Django
 djangorestframework>=3.2.0
 drf-yasg

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 certifi==2021.5.30
     # via requests
-chardet==4.0.0
+charset-normalizer==2.0.2
     # via requests
 coreapi==2.3.3
     # via drf-yasg
@@ -26,7 +26,7 @@ djangorestframework==3.12.4
     #   drf-yasg
 drf-yasg==1.20.0
     # via -r requirements/base.in
-idna==2.10
+idna==3.2
     # via requests
 inflection==0.5.1
     # via drf-yasg
@@ -42,7 +42,7 @@ pyparsing==2.4.7
     # via packaging
 pytz==2021.1
     # via django
-requests==2.25.1
+requests==2.26.0
     # via coreapi
 ruamel.yaml==0.17.10
     # via drf-yasg

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4
-    # via
-    #   -r requirements/travis.txt
-    #   virtualenv
 astroid==2.6.2
     # via
     #   -r requirements/quality.txt
@@ -17,7 +13,11 @@ attrs==21.2.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-bleach==3.3.0
+backports.entry-points-selectable==1.1.0
+    # via
+    #   -r requirements/travis.txt
+    #   virtualenv
+bleach==3.3.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -26,15 +26,16 @@ certifi==2021.5.30
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
     #   requests
-cffi==1.14.5
+cffi==1.14.6
     # via
     #   -r requirements/quality.txt
     #   cryptography
 chardet==4.0.0
+    # via diff-cover
+charset-normalizer==2.0.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
-    #   diff-cover
     #   requests
 click==8.0.1
     # via
@@ -77,7 +78,7 @@ cryptography==3.4.7
     # via
     #   -r requirements/quality.txt
     #   secretstorage
-diff-cover==6.0.0
+diff-cover==6.2.0
     # via -r requirements/dev.in
 distlib==0.3.2
     # via
@@ -110,7 +111,7 @@ filelock==3.0.12
     #   -r requirements/travis.txt
     #   tox
     #   virtualenv
-idna==2.10
+idna==3.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
@@ -130,7 +131,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
-isort==5.9.1
+isort==5.9.2
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -138,7 +139,7 @@ itypes==1.2.0
     # via
     #   -r requirements/quality.txt
     #   coreapi
-jeepney==0.6.0
+jeepney==0.7.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -190,10 +191,14 @@ pep517==0.10.0
     #   pip-tools
 pip-tools==6.2.0
     # via -r requirements/pip-tools.txt
-pkginfo==1.7.0
+pkginfo==1.7.1
     # via
     #   -r requirements/quality.txt
     #   twine
+platformdirs==2.0.2
+    # via
+    #   -r requirements/travis.txt
+    #   virtualenv
 pluggy==0.13.1
     # via
     #   -r requirements/quality.txt
@@ -273,7 +278,7 @@ readme-renderer==29.0
     # via
     #   -r requirements/quality.txt
     #   twine
-requests==2.25.1
+requests==2.26.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
@@ -337,7 +342,7 @@ toml==0.10.2
     #   pytest
     #   pytest-cov
     #   tox
-tox==3.23.1
+tox==3.24.0
     # via
     #   -r requirements/travis.txt
     #   tox-battery
@@ -359,7 +364,7 @@ urllib3==1.26.6
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
     #   requests
-virtualenv==20.4.7
+virtualenv==20.6.0
     # via
     #   -r requirements/travis.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,18 +12,19 @@ attrs==21.2.0
     #   pytest
 babel==2.9.1
     # via sphinx
-bleach==3.3.0
+bleach==3.3.1
     # via readme-renderer
 certifi==2021.5.30
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.14.5
+cffi==1.14.6
     # via cryptography
 chardet==4.0.0
+    # via doc8
+charset-normalizer==2.0.2
     # via
     #   -r requirements/test.txt
-    #   doc8
     #   requests
 colorama==0.4.4
     # via twine
@@ -64,7 +65,7 @@ drf-yasg==1.20.0
     # via -r requirements/test.txt
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
-idna==2.10
+idna==3.2
     # via
     #   -r requirements/test.txt
     #   requests
@@ -86,7 +87,7 @@ itypes==1.2.0
     # via
     #   -r requirements/test.txt
     #   coreapi
-jeepney==0.6.0
+jeepney==0.7.0
     # via
     #   keyring
     #   secretstorage
@@ -110,7 +111,7 @@ packaging==21.0
     #   sphinx
 pbr==5.6.0
     # via stevedore
-pkginfo==1.7.0
+pkginfo==1.7.1
     # via twine
 pluggy==0.13.1
     # via
@@ -149,7 +150,7 @@ readme-renderer==29.0
     # via
     #   -r requirements/doc.in
     #   twine
-requests==2.25.1
+requests==2.26.0
     # via
     #   -r requirements/test.txt
     #   coreapi
@@ -180,7 +181,7 @@ six==1.16.0
     #   readme-renderer
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.0.3
+sphinx==4.1.1
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,15 +12,15 @@ attrs==21.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
-bleach==3.3.0
+bleach==3.3.1
     # via readme-renderer
 certifi==2021.5.30
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.14.5
+cffi==1.14.6
     # via cryptography
-chardet==4.0.0
+charset-normalizer==2.0.2
     # via
     #   -r requirements/test.txt
     #   requests
@@ -67,7 +67,7 @@ drf-yasg==1.20.0
     # via -r requirements/test.txt
 edx-lint==5.0.0
     # via -r requirements/quality.in
-idna==2.10
+idna==3.2
     # via
     #   -r requirements/test.txt
     #   requests
@@ -83,7 +83,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.9.1
+isort==5.9.2
     # via
     #   -r requirements/quality.in
     #   pylint
@@ -91,7 +91,7 @@ itypes==1.2.0
     # via
     #   -r requirements/test.txt
     #   coreapi
-jeepney==0.6.0
+jeepney==0.7.0
     # via
     #   keyring
     #   secretstorage
@@ -118,7 +118,7 @@ packaging==21.0
     #   pytest
 pbr==5.6.0
     # via stevedore
-pkginfo==1.7.0
+pkginfo==1.7.1
     # via twine
 pluggy==0.13.1
     # via
@@ -173,7 +173,7 @@ pyyaml==5.4.1
     # via code-annotations
 readme-renderer==29.0
     # via twine
-requests==2.25.1
+requests==2.26.0
     # via
     #   -r requirements/test.txt
     #   coreapi

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ certifi==2021.5.30
     # via
     #   -r requirements/base.txt
     #   requests
-chardet==4.0.0
+charset-normalizer==2.0.2
     # via
     #   -r requirements/base.txt
     #   requests
@@ -35,7 +35,7 @@ coverage==5.5
     #   drf-yasg
 drf-yasg==1.20.0
     # via -r requirements/base.txt
-idna==2.10
+idna==3.2
     # via
     #   -r requirements/base.txt
     #   requests
@@ -82,7 +82,7 @@ pytz==2021.1
     # via
     #   -r requirements/base.txt
     #   django
-requests==2.25.1
+requests==2.26.0
     # via
     #   -r requirements/base.txt
     #   coreapi

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4
+backports.entry-points-selectable==1.1.0
     # via virtualenv
 certifi==2021.5.30
     # via requests
-chardet==4.0.0
+charset-normalizer==2.0.2
     # via requests
 codecov==2.1.11
     # via -r requirements/travis.in
@@ -20,17 +20,19 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-idna==2.10
+idna==3.2
     # via requests
 packaging==21.0
     # via tox
+platformdirs==2.0.2
+    # via virtualenv
 pluggy==0.13.1
     # via tox
 py==1.10.0
     # via tox
 pyparsing==2.4.7
     # via packaging
-requests==2.25.1
+requests==2.26.0
     # via codecov
 six==1.16.0
     # via
@@ -38,9 +40,9 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.23.1
+tox==3.24.0
     # via -r requirements/travis.in
 urllib3==1.26.6
     # via requests
-virtualenv==20.4.7
+virtualenv==20.6.0
     # via tox


### PR DESCRIPTION
1. django constraint in `base.in` giving conflicting issues in other pacakages with django3 testing like `edx-api-doc-tools 1.4.0 depends on Django<3.0 and >=1.11`.
2. Ran make upgrade.
3. Bump the version.